### PR TITLE
Change localization handling

### DIFF
--- a/cms-contentful/it/com/commercetools/sunrise/cms/contentful/ContentfulCmsServiceIT.java
+++ b/cms-contentful/it/com/commercetools/sunrise/cms/contentful/ContentfulCmsServiceIT.java
@@ -5,6 +5,7 @@ import com.commercetools.sunrise.cms.CmsServiceException;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -13,12 +14,11 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.ThrowableAssert.catchThrowable;
 
 public class ContentfulCmsServiceIT {
-    private static final List<Locale> SUPPORTED_LOCALES = asList(Locale.GERMANY, Locale.US);
+    private static final List<Locale> SUPPORTED_LOCALES = Collections.singletonList(Locale.GERMANY);
 
     // credentials for contentful demo account
     private static final String IT_PREFIX = "CONTENTFUL_";
@@ -56,7 +56,37 @@ public class ContentfulCmsServiceIT {
         Optional<CmsPage> content = waitAndGet(contentfulCmsService.page("finn", SUPPORTED_LOCALES));
         assertThat(content).isPresent();
 
+        assertThat(content.get().field("pageContent.description")).contains("Fearless Abenteurer! Verteidiger von Pfannkuchen.");
+    }
+
+    @Test
+    public void whenAskForExistingStringContentAndLocalesAreEmptyThenGetDefaultLocaleContent() throws Exception {
+        Optional<CmsPage> content = waitAndGet(contentfulCmsService.page("finn", Collections.emptyList()));
+        assertThat(content).isPresent();
+
+        assertThat(content.get().field("pageContent.description")).contains("Fearless Abenteurer! Verteidiger von Pfannkuchen.");
+    }
+
+    @Test
+    public void whenAskForExistingStringContentAndLocalesAreNullThenGetDefaultLocaleContent() throws Exception {
+        Optional<CmsPage> content = waitAndGet(contentfulCmsService.page("finn", null));
+        assertThat(content).isPresent();
+
+        assertThat(content.get().field("pageContent.description")).contains("Fearless Abenteurer! Verteidiger von Pfannkuchen.");
+    }
+
+    @Test
+    public void whenAskForExistingStringContentWithNotDefaultLocaleThenGet() throws Exception {
+        Optional<CmsPage> content = waitAndGet(contentfulCmsService.page("finn", Collections.singletonList(Locale.ENGLISH)));
+        assertThat(content).isPresent();
+
         assertThat(content.get().field("pageContent.description")).contains("Fearless adventurer! Defender of pancakes.");
+    }
+
+    @Test
+    public void whenAskForExistingStringContentWithNotDefinedLocaleThenNotPresent() throws Exception {
+        Optional<CmsPage> content = waitAndGet(contentfulCmsService.page("finn", Collections.singletonList(Locale.ITALIAN)));
+        assertThat(content).isEmpty();
     }
 
     @Test

--- a/cms-contentful/src/main/java/com/commercetools/sunrise/cms/contentful/ContentfulCmsPage.java
+++ b/cms-contentful/src/main/java/com/commercetools/sunrise/cms/contentful/ContentfulCmsPage.java
@@ -44,12 +44,10 @@ public class ContentfulCmsPage implements CmsPage {
 
     private Optional<String> getContent(final CDAEntry entry, final String contentFieldName) {
         return getCdaField(entry, contentFieldName)
-                .flatMap(cdaField -> getFirstSupportedLocale(entry, contentFieldName)
-                        .flatMap(supportedLocale -> {
-                            final Object localizedEntryField = getLocalizedEntryField(supportedLocale, entry,
-                                    contentFieldName);
-                            return getContentAccordingToFieldDefinition(localizedEntryField, cdaField);
-                        }));
+                .flatMap(cdaField -> {
+                    final Object entryField = entry.getField(contentFieldName);
+                    return getContentAccordingToFieldDefinition(entryField, cdaField);
+                        });
     }
 
     private CDAEntry getEntryWithContentField(@Nullable final CDAEntry cdaEntry, final List<String> entryNamesList) {
@@ -76,22 +74,6 @@ public class ContentfulCmsPage implements CmsPage {
                         && FieldTypes.ALL_SUPPORTED.contains(cdaField.type()))
                 .findFirst();
     }
-    
-    private Object getLocalizedEntryField(final Locale locale, final CDAEntry lastLevelEntry, final String fieldName) {
-        lastLevelEntry.setLocale(locale.toLanguageTag());
-        return lastLevelEntry.getField(fieldName);
-    }
-
-    private Optional<Locale> getFirstSupportedLocale(final CDAEntry lastLevelEntry, final String fieldName) {
-        final Map<String, Object> rawFields = lastLevelEntry.rawFields();
-        final Map<String, Object> localeContentMap = getLocaleContentMap(fieldName, rawFields);
-        return Optional.ofNullable(localeContentMap).flatMap(map -> {
-            final Set<String> allSupportedLocales = map.keySet();
-            return locales.stream()
-                    .filter(locale -> allSupportedLocales.contains(locale.toLanguageTag()))
-                    .findFirst();
-        });
-    }
 
     private Optional<String> getContentAccordingToFieldDefinition(@Nullable final Object localizedEntryField,
                                                                   final CDAField cdaField) {
@@ -105,11 +87,6 @@ public class ContentfulCmsPage implements CmsPage {
                     }
                     return content;
                 });
-    }
-
-    @SuppressWarnings("unchecked")
-    private Map<String, Object> getLocaleContentMap(String fieldName, Map<String, Object> rawFields) {
-        return (Map<String, Object>) rawFields.get(fieldName);
     }
 
 }

--- a/cms-contentful/src/test/java/com/commercetools/sunrise/cms/contentful/ContentfulCmsPageTest.java
+++ b/cms-contentful/src/test/java/com/commercetools/sunrise/cms/contentful/ContentfulCmsPageTest.java
@@ -28,16 +28,6 @@ public class ContentfulCmsPageTest {
     }
 
     @Test
-    public void whenLanguageIsNotSupported_thenReturnOptionalEmpty() throws Exception {
-        final Locale deAt = Locale.forLanguageTag("de-AT");
-        final List<Locale> supportedLocales = Collections.singletonList(deAt);
-        final ContentfulCmsPage contentfulCmsPage= new ContentfulCmsPage(mockCdaEntry, supportedLocales);
-        final Optional<String> content = contentfulCmsPage.field(FIELD_NAME);
-
-        assertThat(content).isEmpty();
-    }
-
-    @Test
     public void whenEntryDoesNotHaveRequiredField_thenReturnOptionalEmpty() throws Exception {
         final String notMatchingFieldName = "notMatchingFieldName";
         final Optional<String> content = contentfulCmsPage.field(notMatchingFieldName);
@@ -63,61 +53,61 @@ public class ContentfulCmsPageTest {
 
     @Test
     public void whenEntryFieldTypeIsDate_thenReturnOptionalString() throws Exception {
-        final String localizedFieldContent = "2015-11-06T09:45:27";
-        final CDAEntry mockCdaEntry = mockEntry(FIELD_NAME, localizedFieldContent, DATE);
+        final String fieldContent = "2015-11-06T09:45:27";
+        final CDAEntry mockCdaEntry = mockEntry(FIELD_NAME, fieldContent, DATE);
         final ContentfulCmsPage contentfulCmsPage = new ContentfulCmsPage(mockCdaEntry, SUPPORTED_LOCALES);
         final Optional<String> content = contentfulCmsPage.field(FIELD_NAME);
 
-        assertThat(content).contains(localizedFieldContent);
+        assertThat(content).contains(fieldContent);
     }
 
     @Test
     public void whenEntryFieldTypeIsInteger_thenReturnOptionalString() throws Exception {
-        final int localizedFieldContent = 13;
-        final CDAEntry mockCdaEntry = mockEntry(FIELD_NAME, localizedFieldContent, INTEGER);
+        final int fieldContent = 13;
+        final CDAEntry mockCdaEntry = mockEntry(FIELD_NAME, fieldContent, INTEGER);
         final ContentfulCmsPage contentfulCmsPage = new ContentfulCmsPage(mockCdaEntry, SUPPORTED_LOCALES);
         final Optional<String> content = contentfulCmsPage.field(FIELD_NAME);
 
-        assertThat(content).contains(String.valueOf(localizedFieldContent));
+        assertThat(content).contains(String.valueOf(fieldContent));
     }
 
     @Test
     public void whenEntryFieldTypeIsNumber_thenReturnOptionalString() throws Exception {
-        final double localizedFieldContent = 3.14;
-        final CDAEntry mockCdaEntry = mockEntry(FIELD_NAME, localizedFieldContent, NUMBER);
+        final double fieldContent = 3.14;
+        final CDAEntry mockCdaEntry = mockEntry(FIELD_NAME, fieldContent, NUMBER);
         final ContentfulCmsPage contentfulCmsPage = new ContentfulCmsPage(mockCdaEntry, SUPPORTED_LOCALES);
         final Optional<String> content = contentfulCmsPage.field(FIELD_NAME);
 
-        assertThat(content).contains(String.valueOf(localizedFieldContent));
+        assertThat(content).contains(String.valueOf(fieldContent));
     }
 
     @Test
     public void whenEntryFieldTypeIsBoolean_thenReturnOptionalString() throws Exception {
-        final boolean localizedFieldContent = true;
-        final CDAEntry mockCdaEntry = mockEntry(FIELD_NAME, localizedFieldContent, BOOLEAN);
+        final boolean fieldContent = true;
+        final CDAEntry mockCdaEntry = mockEntry(FIELD_NAME, fieldContent, BOOLEAN);
         final ContentfulCmsPage contentfulCmsPage = new ContentfulCmsPage(mockCdaEntry, SUPPORTED_LOCALES);
         final Optional<String> content = contentfulCmsPage.field(FIELD_NAME);
 
-        assertThat(content).contains(String.valueOf(localizedFieldContent));
+        assertThat(content).contains(String.valueOf(fieldContent));
     }
 
     @Test
     public void whenEntryFieldTypeIsLinkAsset_thenReturnOptionalString() throws Exception {
-        final String localizedFieldContent = "//some.url";
+        final String fieldContent = "//some.url";
         final CDAAsset mockAsset = mock(CDAAsset.class);
-        when(mockAsset.url()).thenReturn(localizedFieldContent);
+        when(mockAsset.url()).thenReturn(fieldContent);
         final CDAEntry mockCdaEntry = mockEntry(FIELD_NAME, mockAsset, LINK, true);
         final ContentfulCmsPage contentfulCmsPage = new ContentfulCmsPage(mockCdaEntry, SUPPORTED_LOCALES);
         final Optional<String> content = contentfulCmsPage.field(FIELD_NAME);
 
-        assertThat(content).contains(localizedFieldContent);
+        assertThat(content).contains(fieldContent);
     }
 
     @Test
     public void whenEntryFieldTypeLinkIsOtherThanAsset_thenReturnOptionalEmpty() throws Exception {
-        final String localizedFieldContent = "//some.url";
+        final String fieldContent = "//some.url";
         final CDAAsset mockAsset = mock(CDAAsset.class);
-        when(mockAsset.url()).thenReturn(localizedFieldContent);
+        when(mockAsset.url()).thenReturn(fieldContent);
         final CDAEntry mockCdaEntry = mockEntry(FIELD_NAME, mockAsset, LINK, false);
         final ContentfulCmsPage contentfulCmsPage = new ContentfulCmsPage(mockCdaEntry, SUPPORTED_LOCALES);
         final Optional<String> content = contentfulCmsPage.field(FIELD_NAME);
@@ -127,9 +117,9 @@ public class ContentfulCmsPageTest {
 
     @Test
     public void whenAssetHasNoUrl_thenReturnOptionalEmpty() throws Exception {
-        final String localizedFieldContent = null;
+        final String fieldContent = null;
         final CDAAsset mockAsset = mock(CDAAsset.class);
-        when(mockAsset.url()).thenReturn(localizedFieldContent);
+        when(mockAsset.url()).thenReturn(fieldContent);
         final CDAEntry mockCdaEntry = mockEntry(FIELD_NAME, mockAsset, LINK, true);
         final ContentfulCmsPage contentfulCmsPage = new ContentfulCmsPage(mockCdaEntry, SUPPORTED_LOCALES);
         final Optional<String> content = contentfulCmsPage.field(FIELD_NAME);
@@ -138,17 +128,17 @@ public class ContentfulCmsPageTest {
     }
 
     private CDAEntry mockEntry(final String fieldName,
-                               final String localizedFieldContent) {
-        return mockEntry(fieldName, localizedFieldContent, SYMBOL, false);
+                               final String fieldContent) {
+        return mockEntry(fieldName, fieldContent, SYMBOL, false);
     }
 
     private CDAEntry mockEntry(final String fieldName,
-                               final Object localizedFieldContent, final String fieldType) {
-        return mockEntry(fieldName, localizedFieldContent, fieldType, false);
+                               final Object fieldContent, final String fieldType) {
+        return mockEntry(fieldName, fieldContent, fieldType, false);
     }
 
     private CDAEntry mockEntry(final String fieldName,
-                               final Object localizedFieldContent, final String fieldType,
+                               final Object fieldContent, final String fieldType,
                                final Boolean isLinkedAsset) {
         CDAEntry mockCdaEntry = mock(CDAEntry.class);
         CDAField mockCdaField = mock(CDAField.class);
@@ -162,11 +152,8 @@ public class ContentfulCmsPageTest {
         when(mockContentType.fields()).thenReturn(Collections.singletonList(mockCdaField));
 
         // mock field content
-        Map<String, Object> mockFields = new HashMap<>();
         Map<String, Object> mockRawFields = new HashMap<>();
-        mockFields.put(Locale.GERMANY.toLanguageTag(), localizedFieldContent);
-        when(mockCdaEntry.getField(fieldName)).thenReturn(localizedFieldContent);
-        mockRawFields.put(fieldName, mockFields);
+        when(mockCdaEntry.getField(fieldName)).thenReturn(fieldContent);
         when(mockCdaEntry.rawFields()).thenReturn(mockRawFields);
 
         return mockCdaEntry;


### PR DESCRIPTION
@lauraluiz I've updated localization. I am following current contentful localozation handling.
It means that I've added query for locale with first of the list locale value.
If locale is supported by contentful space it will return value with fallback to default locale.

Current implementation was wrong, because in raw fields there is only one localization.
Multiple localizations are fetched only using syncing API.

It is possible to use syncing API, and choose correct localization, but using sync API means I would fetch all data from contentful (Or all data of one type. And in our case all of main type - eg. 'page'- which means all data anyway).